### PR TITLE
Animated SVG seems to be inheriting the parent container dimensions -…

### DIFF
--- a/restricted/cred.html
+++ b/restricted/cred.html
@@ -150,8 +150,9 @@
                 </section>
                 <h4>Animated Vector Graphics</h4>
                 <item>
-                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="500px"
-                    height="500px" viewBox="0 0 500 500" preserveAspectRatio="none"enable-background="new 0 0 500 500" xml:space="preserve">
+                    <svg version="1.1" xmlns="http://www.w3.org/2000/svg" 
+                    xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" 
+                    viewBox="0 0 500 500" xml:space="preserve">
                         <mask id="mask" maskUnits="userSpaceOnUse">
                             <line fill="none" stroke="#FFFFFF" stroke-width="15" stroke-miterlimit="10" x1="190.25" y1="149" x2="308.5" y2="350.333"/>
                         </mask>

--- a/styles.css
+++ b/styles.css
@@ -1745,6 +1745,7 @@ ul{
 item {
     max-width: 300px;
     min-width: 200px;
+    display: block;
 }
 }
 


### PR DESCRIPTION
… not entirely sure what changes led to this - the viewbox definitely needs to remain original as the coordinate for svg elements are based on these units - might have been adding "display:block" to parent container...