### PR TITLE
Early version of email signature template for outgoing ASC emails.  I…

### DIFF
--- a/mail_sig.html
+++ b/mail_sig.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;">
+    <table style="display:table-cell;height:150px;width:100vw;padding:20px 0 20px 5vw;border-collapse:collapse;vertical-align:middle;background:linear-gradient(30deg, rgb(86, 54, 148) 20%, rgb(62, 60, 127) 41%, rgb(47, 64, 114) 74%, rgb(43, 57, 96) 85%);">
+        <tbody>
+            <tr style="display:table-cell;vertical-align:middle;">
+                <td rowspan="4" style="padding:0 5vw 0 10px;filter:drop-shadow(0 10px 2px rgba(0,0,0,0.4));">
+                    <!-- Below, the BASE64 img did not load in Gmail. Will try plain .png or maybe SVG again -->
+                    <img style="width:8vw;min-width:80px;max-width:100px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHIAAAC6CAYAAAByZhmkAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAGXRFWHRTb2Z0d2FyZ
+                    QBBZG9iZSBJbWFnZVJlYWR5ccllPAAAGtRJREFUeNrsXetx3LiyxnH5v5CBcCIQbwTCRiBuBEtHYG4ES0ewdARLR3C4ERw6AzqCy82AimCuWBcofWp340FyRhqbqGL
+                    Zmhni1ej3A/86nU7qB2v66SmeHit8Pzw9k3t+mPavHwSQ5umpnp7y6blLfOefp6d/etofAajXDkjjAPFAPv/29IwMgDy23pPPvz49tXvnOtsCyCt89NPTnl62/ump3
+                    HcpfZTuHWxtxvtv6rlGIBZPz0gAaDb0t7zbQX+TG+Oq9uXaSGvhhJWbp+fR8cRhp74X4ah7em5d35XjoQePPCMQv7mNnxmeWbrvDPO9dp8NDkgj830PPPTXqwHmFZH
+                    TGUgp5WOVI7eeT5oIf63cb0f3f/obT2rnayGz1yLYeJ44EiB6ftmt5JOePy59WPLdADxTHzxym1KvHa96cHwLyWXtvqt2UBsKxx8XMtrAHEbHM/8GdWbakS//kDyyB
+                    P52y3yP/Kpz/1Y7z4H2u8zlv8Jv/3bz6Rle/NMBUgNm3TJKujepzU7xPycQJWDWbp4KhCic66ObW/uqAH1Ful46/nMCwaJleBU+teNp557bMkYT4a010Wdn99lPI+x
+                    oRgGvMgwBlxI8xsih8o8Fwejk/q9/dGFHO1LpDdufAiTJezC84FM4Hnope6gXgGb3jO4ZhPnWTlC6cQb5S871ooBEIEpWGeM2w7rv0OX0mh4KAwfLurm0zPwLJ/x46
+                    5C9FDAvBUgKRLpA78XQ7t9+BfYYUFmKyO/9wRjh39zxajh4g7DWf9xvzy8EXYiGhywldQY/Qn7ZEN60tQ2uz2KFAb9h5IAJ+r1qYcc44NSwWZYBcJcoHBROqp1O52+
+                    TGysVqC0j5KBZsXFrL65B2ClAob9nvv8EVhOvr03kM65VjoyleP6/gVE85unQiX1+dXPtEudpifXpT6HP0fU5vhXSWhF9ipKrwRmoc/Q0328I+2bXb73xpBeujx4wS
+                    MLSKmHOdK097APX/5iofp2NtFpmo7sE7wO32Fi/CLzOGRPOaajoAkCdIvy8ixgGtDDGlCknbAYkDbOYHXbpBH5pA94EzYReUGzQK/l0sXKdIarQB9YxOmDFxtZu72Y
+                    SbnJ2HkkV+s+Ox0kO3tK9gyI+59AtHb+4IZ//4/rvEufnx5zhqWB8bzMdM43dlZsHtQdLkQReXkAddAYjOxcUtvT/EXhomaW2rPQLzgIZQP9eKgZ1AgmtMvk0R3JrI
+                    OWGkYDbTD9mLZDcNgPDQ/7TEvrPMkeuBWIhiOA5+qAWhKQ+YwHW/d4GeK3fIG5jPGnLiZ6TWMCYOe9REPgKAsxdAdkHgGgCkwpJihODhTlCTBMYs3CnviUef8mgbQI
+                    HIkQFZgaYReYauAOAwGz3AmQJEy0EgORaZbZuQBsAOpJZS97xpL8IbGx1yrfs0ANZZErJ3AErA4aUbEBqYp3gzFDFRiDmun0ki4sG9UcxkrT/25PTOnAQqpWyw1pgS
+                    i66FqT2TYBsAh3l2kc1A8RcJ3HNbDLyOUM2gfIlS/7uBKC1K3S6jlGZdCapHgJ7Vm0BpNRJk8kTuVPbndbprwpsuCHJs4kAEj/3/VSASf0KvbXbIAD5A1QzAI5iZUi
+                    PXPSjv5wuZ4iOOJDPYq1XLxNtvkRibrTTo7z+pYl+6CPc2oCtsiF2XAsxQNx41tlG8bM7ZyNGHXqI6He5a6XzGBnX1+x0bDlgOkFSrZlTV2WSw9RTakHapGSwIaY9D
+                    YJNzfSZgpGIjZb0PYDXgptfkUF96kwS2wi8sltDWmdGUtU5uo17lwoBIfG/EjbG8xsp+Ip7v2WkQEvUkyoACL/5nEAX0z8NkQdyhZ+JOXBB8hoDwMyclpzTRU+mFTC
+                    2CdgtOwCeB2oXMXh7oBsGQ0P8XYO3Qif4THXAiG8ZSrRFvfKNpWbvAjEqiuE/NiPKuiH+vk/Muz7wSrLXtmCfVGCvHAT7q48U91nIlvAfz1ObQLCVj1yfoU//0BASb
+                    8stGD44OFu0b3eEB8dkCsv4WpUYxhJRO1oGw9aoGmOGPkgxi9MHPdWQciM5TD5FDAGtwF9xDm2m/qmZ2N1UKXYQclFsDkbiiQv9LbWWeDJq5vtewPgepOYZUuEUUAk
+                    fvFVBGKIm86whEmD53QdmvAowvIYTP5G+DPTpPfuWiVA35POZYOpNQkQEpYp071lt4X1mSOCc+LvfSI7EQICFiTAGwgxHAGDKYZpJNJsiKkLpPjfEreRVmwE+RxI8M
+                    VF3ivSPh2AAkt0T0jw4t5QPf/mo0gpQZIV/5gJyTOSNSsBGrZ6zngbgB0OGz1FadA0+yQEAUkAcj4E4oXaHHBGPhTXwVs+LK4L5/0v2pM4cT4cA/C5yGgqhs5gij8r
+                    wRBYwAMB79bK0ypZWAcmrQQDxjtwSMNcLNk2mYYMe7A7IbUHidQ3Zzy9krlrt2QKKOSekDJnKv2EEHMnYXgm6XUgfxPesoP4YJ6xI+ifVBy0j+reM87wRMqc7Yk6Ud
+                    OoqQXVLVj9CHXEvjhl648AssoSNkdxJJbFzNoLFxut8ZUAX68nmt5HM5TIyZkjnLYji3wqSaKpeOTKHQDQIvIvEiCpC8uYASTBEb+yEvAjUzSpG/+qBTBYgpSL5LuB
+                    3PUPeW4jL8aRtdn0OzBom15dhyJ4Fu66k85Yw5xGEHE6yRb3SBGKER0KKVUiHfxdh5ops9BDgZSUJSgrlbwyQP6EE9aEECbYkG1spvqpH4Ta8AyO3IqqLD/QqBbVJQ
+                    dAYBnRJQcoNWYsKALIP7FnI8FIK7ycZzQ3D64pATCotYhRzK3F8pwqE42MwtEqwfTYMaS+YpFkTiRSQnOeW8GbDGAvagDMilBeCjoVSMJdm+SM7BjADs3gdYeQFs8g
+                    msDk1w5srxkcYioZrE7wfeAAss+HUtoylXaqE/hvBAoRN2gOKIEH/b0yP7Jxy/wA6WOvISUVIGiUrnJ8t1gZCdguISf1LPRf/w88bwVCRYryYgayXQFq93/Mv9ZyMi
+                    7beLTrvECGj6EctQO4IphrGTHQlBMxOAT5pSVDxtGGhJQgcA2zcV/WyahUNBN7SLORWzm7+Wj1XmRyJA3qLDjg5GUIFdPURePpXRlbJtuxUjLWmYqwiBREoFCNk1BH
+                    PSQW21pqhDA0IPx1jn6VejRTjhTfv0TELEKoacljQHLi21usIJjvDrBX3uHW/LYPWoIQwyIlxeuqAoNME9DrubxNQ6DH20/OPOSB89PBdwxgrjCCocJ4bC2trAjFED
+                    eG3MWFHkdwZLuBqEHR6s0aP5ETeQohZuYtgJIcNM5wyCVtrogp5stoKfLlUL6thWYJJE7xbKb4GQAu8GseuGf5aE1KvSV9TgleJ83JQavI16IuM8MiCAWSKY3lOMPy
+                    WIGDUiq/i2AK/Ghgds1Z83fKaeFU491kr8MnGvU+9Hd6g0DKbPAAp1IJLLiTw3Aqk1zK/XwXIO2ZQK5ziFPcLKuEl+Am5De2Id2Ek/WvwzDfM5nbEF2hBqR+EQ2Nhf
+                    tT/WcB8WmbeM0jTJXHXrRWIstr7CDY+JvjqdOIkvDAyCFJYCS6oMtD/SMikARWkg/E7IrTQmuVojmuJx2cIrKEC0yDWoptBOJoilIsLa+Gc2ZRd2VxAaoHfbXW9eIy
+                    owZmsCYnK1QcnkD4r2JQBpF3kyQVgeZd4+mfBF+n1XdwvT4LLiNQaAiQlrfNajFzD/1JJhnYT18RZOu7Q90D47wxCBx6aGXjfljYT4cTAc9GWC8itGFkDCa0ZMmcEP
+                    pbiVPb8Gy09NeiBiH0oaA0rLDUYNdeSfmsQmpoNBoqRkWynXGFnFgSZLRjpydkAfAuxqQGSiwKMZjZxIpLhBG6kGb6rgQz2BCO94j2pl+GHk5IjIzQcDE7C9WEr7Q5
+                    YOe8BSH8abpjOTQS4RQBreiLBVoLtE3nQpL7PPfGAt4qvaVeQ8Xqwk2pB/7QgqHDjoeRK7bteYML6dH2AT+qEQ59FCVMcy1SfsRHGrQOTn8jJ1QL5mdRLf6RlNk0KN
+                    PYSak/0OG8mlLClUc8OZErmZpBWOam9B1UJD4+NaAWSId2Qz4qYseVdgmRVRgAZO02SYGLUS0++EXgqrZBRMkDyG9oBMKmXfQYJtxHslj1QiwLWXwiGC3RSj4IasWa
+                    PtAD4aQ0gewaQXjmWTEihSUrxqT1gUce8X4MkyJnzPFY36mUpFxrYPKjn0MgK+HUl6Ls4biMAUKmXZVTmROpkhL1TzAE0wOLGNVJr7wwCt8Si0zES2aSerfk2QQpTg
+                    mXEADYNsNnoK/QCUQEbwnkhYoLZQCw+M4zZgYXJGw0srG1UaTmPXKQ83aMpIEsgIv29Rf1YFvIRBAv/2cgAMibszIkkt1Evg35n4JMz8NZB7VOUrwegNmSu93CANAg
+                    zqfrnKFiKQm6/ipD9mlDITYC8B5TnrPrLRP8ASZfjT0XCwiv1MmqtJnZLQ/ilVS/zMXLVIwNjDGSOy9+f1feO7JocpFwDSkG0AQrkFlQpo56N6uG1JRaDGEkcjw3Ew
+                    UoZuiFfXcg/WCQkutrMRFf0JerALQOhyiUV8X+mBHzhnkoBVZr4gLuUAr65xSB0IEi2j0TRdUzQk4qUSjlHoquNXFXYQYS6/3uIpOQ1wuFpItGGXWAORSCaMdux7Cv
+                    md4y0pgK60AMjsc2k70G9dBRzJKhT+ya6el2wFPhcBwIP6rytkv2fqH+OhDxrhpTfBciqIpK8lxu+EH6ZRVo7Jtk1FJJhIuSVlj4JnfIaYlT3SnSdAphvAmEimklbl
+                    1IGBma/pBCPUyTpdWDCbsY1pHViMmRjSTw9KRjEba6OxN3QnPy1vC6liAQX2FxEEolChSQqWDfXz5RRZ2gU4oZ1blzrLYP+OkGUf4D3Uf+cQV+sQKrF+zR6wf4q/b0
+                    m0VUTX2hDyKyO6KQjSNcdGOBR//S6cEMk8ltCxlMl3tmZTO+U5PjeOa1OkdoBg1C2xFdqHBNKZ6dWsFKkpOcEdcRH93//mY2U4EyJGKfR5y1IuzPzzhigViqhjFofq
+                    tnzfoUeFGst6JT3BCsn8CBMgBmWwYzcVoHRwOuWGMZRAzZiWMmWq3cL9TLhx1MCany3RMhJ8VPOjHHhQaSKEYwcVmCkjmClZurWSIUB90x0rQKF/Gh1qzIyhwpuONA
+                    J1UpysVExVTObUNzwu8wTaBJPEp7Ge8L3ZvDdUT9kw3gmOH/nAO4jbwTnLCQTUAEuFtbzNB+ZoBkLD3W098B/6QVtnhKM5LNcbMyniCsw0iRiZay+TBEoAYaKPVdAt
+                    wjUedVQ6ZFaekJ19DSoIC2DoXWkmnEj1NmZV2Ajlx3ehjAyt4RZToXhkqlVzo0j6YIF5C/SNLM2UgK7YC52aYEshmqY0+uR2kCdvFgZsz6hhJtKSK2LFkzKrSFQZNZ
+                    Z7RMKINAcCm6TepLomlJkPmT3LCLYOZBE1ypyGY1JKIzRb6xFN4fMdCmFHcqEJJ5UwSdUJdGC+G6Eao17J7rGxuSKKBZCadA1VTFTq0MWsazl9xHH6x2EViCzrjNE6
+                    EUQ+Q+4uAbFV9Ea4LsSBCsfovGnU4r3THTlxjRga/WJrhjVN6pwOp1hBK+cy1gqxlhQRX2SibVWtSDW55CKLSWivTHBqwoVKV+9xZBgwITXgHDVZa5RKrqbWzKco3i
+                    zQB2T3ViDMJnylH/BZb8DMDkdzbulmkzSaoA3mxN/0ehWIHYr9mhVTfOUssyeNptT/tWBsYWuAWa/Q6JryIthMgWTvdbG3eK32y0DiJW9IBBVOyy4yOwj5AJrocqWZ
+                    cqndREhJfd2Ae5WoTVAPOu9H5RX1pH631suPCkz++git/HUBCu7yC089pR+TTB3KdneQKz2vImH04mqgK6nM7GKtty7E0NFj9A3aAX2oBIqI6fcoYm6Yu5laf2l7sb
+                    iLiephE2dMkktd+Vg7g0/JlCksAVMK4T3cq8elG6c7TIA2Lg+pKL2c64RYe019JJfTEMVjtRbw7lb304ryBxGAng+6a/36xm1pc4EoDltu+vS3zEyBgStei2JXnPr+
+                    aKs/gbh7lJiSwkR4d5HN6uXVRtpoBW9hfwRPCXzCl8hFwCWG9CsIVXhhkl0qoQg44qkLowB/6f3vvho/Zzbe5LiWlNvNk1Rni1giAko8dIl1d1p2+3ma25D74S5zJG
+                    7Q1LNmHSMOZNX73LruWEElvEUv07eRorOmsAG4hjmDMDzVp4xMH7s0I4BaVoTEksFpdVr2mPx9hS+rXwQvN3dhn6x/w744Zq5+wiDKTJWCtXpmFDKOaHfzZRmDY8MR
+                    Q9YyCekhYD+Jil6HTEIh/ptIGA61h4JzxqYDKgio68+MZ6IW0+rnm8yxzS6UaXdfHd2HpnDZ6qA2tJkGOCxVuq5W5+hRhnBKJKl0G99LiU4NAF/pF1hHfJWlVYwLOS
+                    2ATwfKlMf5PTebIX+LZHWlDzEB0euaOKrF/FLyPeYVpB2Q9QOrV7m389EDZlWjlOB35CqRj447MaRUXuJzb0kIDU4q5f2gXGgaqKD0YSaQV22FXA4DBxALF2mSMTcn
+                    6Bj2t144BsCpAdUB2kFf6vva9Uogk0F/H9Q269CygFiB9lfIWOCcfN6AIW+vhQQLyHsxHgmKtfmlOY1uYRRIHUsTuetX2NPXwuQmIbGSYsm8M4aZ/Qam3IV0D05o8F
+                    wYcvTmwEkbswQkCYH4uqpzgzMjhgrWkgGklQV+9r7+BYASc1j0qY1jDO22Jmc0kTVUrAmxSjHTw1IyS5ZC4p1sVL/DNl/K8G81r0loF0bIDk/KDUoeE99rkObkvVeC
+                    FA+XYgnX5VBYC8dlDMoGDAoeJ/fyKg1hmRIYxGH1LHeZLsWQHIbXAoGAqte3qzDRZePAQdvf21AfE09cqt+h8Fae5E9dJbPr6lK/Mg8kovaQymy2lH9Gd+6YHPNPJJ
+                    rPmP4FnyHaFJLyf2vyPutWl+H/OCRG1vlNv+WCYyawd6pIRV+rwCvA5BnwlAfuXeb6Pkf1La7IA9AXkDCLUASVaCKjNeMeT8bIH+69u7YggOQRzsAebS9W+rdWAakw
+                    pTmL0vxN6SmtClRivS37BSJ/Xbq+baAKmP+MX3UxxdZlX5nmFV8BS6p+digaQ8TXbMyvBAraOU0qYa4XhnT2mxch87IIIs1tTJ8M5riHyOtWOnxUu1WPZdMwbZ89nD
+                    hudwzWLlg4VK25eaC8/gjRtneJZAOxVhMfnHPlw2T8338znx3o8JlMn37Av18WzmP2Hru1Msih82Z9iS2lipEwt9HLCXcqZsVn0+R24bI9w9kESG+qjYo+Snr8XZdy
+                    Wq0x57E1nKjApcDvIsIOK/dzBuZiwFB6y3MYxf1Y+EbJ/f88VoTB97h53J/Zr6t1PYbbc+2lkOPPAwCR7t2QO4lte7R9pBa30rbtJb3KwbcS2rdo+0htb6VtmktB2k
+                    9eOTRDkAe7QDk0fYTdo72fdMg+JlrAeS082+nDfO/9FwkaXIxrP93Zwk2y7qzhrR2Cb8ZYEJfEyb9z4p5+JDG1Ln07p2U30qt3wFIw057vBqQyyZ8TpjIUuChgb/rB
+                    GCWmcD8R6UVW/id6GZVZJzlUH0IADz2fUpr3B7FgP05Z5xQOKQh9H5I+E0oZjSlP5pB5fvDz6XqGvTd0IFL6c9GMMluxEaMvfWHZIrMQ/rNEdd6qB9HOwB5tAOQRzs
+                    AeQDyaAcgj3ap9j5Bz0ptqXmHsb6HiB4q6lIR3c7ri1R/UwnvpDa7si+qY6vs/YlcbJbb2kjVjCkxrJ6rSiWFz/uiSfOZ0himSMi+jtyKQMcPre20Yn+CVT2GyMJCr
+                    Qpc85s70SqSB2EycjC25KNIFbCKFeNLl6NuAuQa70flyMBfwvc0GnqxLXLh/l8TyNRfkd8s49Bo+EeBhKWQyG/AHqj3wacONPBZv3L8ZW0fmd/gu3mxrSsw0hf2Sz1
+                    5c87JilyAhhhZZJAwSs5ia1MJGFGtHF8FssqGjPE3Y6TKZP5rs5ZiAkmpXqcVDmvMhj5Sssq+5nT4liME7la+ZxSfMTWpfUqx6MSDtnXuA2Eh07UCcm1b8jT+EE54t
+                    +M4+oJzH84JyF8C+tLR3ohBINRisSkXu7REaFuk1tdu0tzntYBMWfT9G92MUb1+KsPF5/4+oJ/piCnuCC24AtLaBjDuF3X5q41+tmYDLIxlXYf34wdpByAPQB7tGnj
+                    kGOCRZkc+oATld6uibgUR/hIqyJbx/bsh8yO/P4HrjU6Bq9ttotHcrnAVxYzGxcqSZG3CBdYpRnO70mdbJ/Sd0kxOCbPFHPRB+O5G7ZuwQqXlUPu2AatawIyUHI7PO
+                    6+t26GPD0ow1b2LDPxv9f9FCs5daGHJhfg1sNglX+OTyvd4PLr5/w/ZgNptSmhdtRtzy9px/LWmy2+uj3+HDsORMnBIrUc7AHm0A5BHOwB5APJoByCPdgDyaAcgD0A
+                    e7QDk0Q5AHm0/QC5R0/7qnhN5bOA3iyeiUy+jr5fPK2asRj0HbPm+ZmY8P2ZDxsdm4btB8YFgg9A3juH/9cWXikA/vvnb1rm5h1poPSqwDpUy9nv1MtDnm/reTTIHf
+                    mOent/U99fF+yyqTpjQ8vmdepn9RMfc2tDdtcxtcb9J+RTafT/AZnFtAfif7v9fL4x0wbHfq+dbZn5Vsp/ObwoXQbf4+T46LMTNCwHTA7GInL6tC8fTfk+wQcKM5cB
+                    +EOa9YNWjm/d0YUAGx14A+eAgHHK23rnfDMKGfXQb7wH5uxtYAuZXt7G9+t5RPKjXC7f0pJqbt8fqT24jreLLnA1nmheOrThAppKy0Al8ZDCYbgrFttaRZks26w9HH
+                    V6jheZNA7bp3O8BmOdqc0jY+abidyB+c5uvBaDcMAvwm/LoNqUkE6rgVFsyByTThXBCzw1MP++CAKgEbLUCZu7dBtgXJWHkQgL/4zCuFQQT6TfakdVH9zsTOOGY71g
+                    pPhqPVoZ8dGMbIP2le/+RHJ5GmPu0ETMxUfeToxhjgBUZNz9p7EqFK09K6/js9pofGypuxCLLpN/gxZ2WiUajRRNiEWgz9FcKxSemxGg2+hsuBd1CRJ4S5j0lXozaQ
+                    L8m40LVJnEdYgEJGrPD1cCh9XPwNxM5db6GDVdzR7vTOiq51k5K7dSZUS1iCUf+N4MwVz+3QcAwTkawghzhqQfHU01A/tAJ6xDHPoKv9m9eCOouOej/CTAALNEHL8b
+                    SCHsAAAAASUVORK5CYII="/>
+                </td>
+                <td rowspan="4" style="width:4px;vertical-align:middle;background-color:#ffffff;"></td>
+                <td style="padding:25px 0 0 5vw;font-family:'Helvetica';font-size:18pt;color:#ffffff;">Nick Moore</td>
+                <td style="display:table-row;font-family:'Helvetica';font-size:14pt;text-indent:5vw;line-height:1.6;color:#ffffff;">nick@anandascience.com</td>
+                <td style="display:table-row;font-family:'Helvetica';font-size:14pt;text-indent:5vw;color:#ffffff;">anandascience.com</td>
+                <td style="display:table-row;"></td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
… initially had used svgs for the logo image, but after researching opted to convert a .png into BASE64 and place in table column.  When testing for gmail, the BASE64 img did not show up.  Seeing as many many people use Gmail, I will have to fix this.  Planning on reverting to svg first, then trying png if that doesn't work.  In order to use png, I have to reference a web address (or store the png on my domain).