### PR TITLE
Updated CSS for MOBILE header ASC logo glyph - changed "scale:3" to "…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -916,7 +916,9 @@ header {
 }
 #logoGlyphMobile {
     /*width: 20%;*/
-    scale: 3;
+    /* scale: 3; */
+    transform: scale(3);
+    -webkit-transform: scale(3);
     left: 10vw;
     top: -60px;
     position: absolute;


### PR DESCRIPTION
…transform:scale(3)" to make it work across more browsers (also webkit fallback). closes #413