### PR TITLE
NM Portfolio - Modal script corrections

### DIFF
--- a/nm_script.js
+++ b/nm_script.js
@@ -176,7 +176,12 @@ $(function(){
                 $('#menuButton').addClass('mb_modal_open');
                 $('.home_link').removeAttr('href');
                 console.log('m:'+m);
-                $('.modal_content_0'+m).show();
+                // $('.modal_content_0'+m).show();
+
+                // $('.modal_content_0'+m).removeAttr('display');
+
+                $('.modal_content_0'+m).addClass('m_show');
+
                 // targetContent.show();
                 // $('.modal_content_0'+m).addClass('m_show');            
             });
@@ -193,7 +198,8 @@ $(function(){
         $('body, html').css('overflow-y', 'scroll');
         $('.modal_screen').removeClass('m_s_o_mobile').one('transitionend', function(e){
             $('.modal_scroll').scrollTop(0,0);
-            $('.modal_content_00, .modal_content_01').hide();
+            // $('.modal_content_00, .modal_content_01').hide();
+            $('.modal_content_00, .modal_content_01').removeClass('m_show');
         })
         //=== new on 20221104
         $('#headerMT').removeClass('headerMT_modal');

--- a/nm_styles.css
+++ b/nm_styles.css
@@ -482,6 +482,7 @@ p.modal_intro {
 .modal_scroll {
     overflow-x: hidden;
     overflow-y: auto;
+    /* overflow-y: scroll; */
     height: calc(70vh - 98px);
     width: auto;
 }
@@ -1365,13 +1366,23 @@ iframe {
         /* new on 20221104 */
         height: calc(100vh - 120px);
     }
+    /* .modal_content_00 {
+        display:none;
+    }
+    .modal_content_01 {
+        display:none;
+    } */
     .modal_content_00, .modal_content_01 {
-        display: flex;
-        flex-direction: column;
+        /* display: flex;
+        flex-direction: column; */
         height: calc(100vh - 162px);
         overflow: hidden;
         /* new on 20221104 */
         height: calc(100vh - 122px);
+    }
+    .m_show {
+        display: flex;
+        flex-direction: column;
     }
     .modal_top {
         display: block;
@@ -1428,6 +1439,13 @@ iframe {
         height: 121px;
         min-height: 121px;
         outline: 2px solid rgb(43, 57, 96);
+    }
+    /* Below is to position thumbnail images so that the user can see the subject more clearly */
+    .m01_qimg_01, .m01_qimg_02, .m01_qimg_03, .m01_qimg_04, 
+    .m02_qimg_01, .m02_qimg_02, .m02_qimg_03, .m02_qimg_04 {
+        width: 100%;
+        margin-left: -30px;
+        margin-top: -15px;
     }
     .close_modal {
         display: none;
@@ -2325,5 +2343,10 @@ footer {
         /* width: 105%; */
         justify-self: center;
         overflow: hidden;
+    }
+}
+@media only screen and (min-width:400px) and (max-width:770px) {
+    .modal_unit > .modal_img {
+        max-width: 200px;
     }
 }


### PR DESCRIPTION
Removed all instances of .show() and .hide() when clicking the button in graphic deisign items to open details modals.
This was creating a conflict as show and hide were adding an HTML attribute onto the HTML rather than in CSS and the default was display:block. There was a conflict with this as the HTML element needed to be display:flex rather than display:block, the latter of which prevented scrolling in the modal container.
I had two options to resolve this:
1. I could modify the CSS directly with the script
2. I could add a class that gave the HTML element display:flex

I chose to go with number 2 in order to resolve this issue.