### PR TITLE
ASC Page - Jquery Migrate Deprecations

### DIFF
--- a/asc_script.js
+++ b/asc_script.js
@@ -8,7 +8,8 @@ $(document).ready(function(){
         $('#logoContainer').removeClass('logoReveal');
     }
     // Above might not be best solution, but cannot think of another now
-    $(document).scroll(function(){
+    // $(document).scroll(function(){
+    $(document).on('scroll', function(){
         if ($(document).scrollTop() > 450) {
             $('#headerMT').addClass('show');
         } else {
@@ -16,7 +17,8 @@ $(document).ready(function(){
         }
     });
     //Below will be used to have logo move into header in FULL
-    $(document).scroll(function(){
+    // $(document).scroll(function(){
+    $(document).on('scroll', function(){
         if ($(document).scrollTop() > 430) {
             $('#logoContainer').addClass('logoReveal');
         } else {


### PR DESCRIPTION
After updating script references in head (to v 3.6.4), ran Jquery migrate (v 3.x) to identify any errors, deprecations, or conflicts. Found two conflicts (line 11 and 20) concerning the use of .scroll(). Found advice on stack exchange that said to use .trigger('scroll'). I tried this approach and it did not work.
After reading documentation on the jquery page, I opted to change these instances to .on('scroll') which resolved the issues completely.