### PR TITLE
Contact Pages - CSS fix for scrollbar intrusion

### DIFF
--- a/contact_styles.css
+++ b/contact_styles.css
@@ -1,8 +1,8 @@
 /*=========================================================*/
 /*-----------------   CONTACT global   -------------------*/
-html, body {
+/* html, body {
     height: 100%;
-}
+} */
 .formContainer {
     overflow: hidden;
 }


### PR DESCRIPTION
Removed the global CSS rule for html and body elements to have 100% height. This correction seems to have resolved the issue.