### PR TITLE
Contact Pages - Added selector to form.serialize()

### DIFF
--- a/scripts/contact_script.js
+++ b/scripts/contact_script.js
@@ -151,7 +151,8 @@ $(function(){
                 type: "POST",
                 dataType: "json",
                 url: href,
-                data: $('.contactForm').serialize(),
+                // this needs to be tested before pushing to production - pending changes
+                data: $('.contactForm', 'input[name!=botCatfish]').serialize(),
             });
         });
     });


### PR DESCRIPTION
Added a selector to exclude the hidden input field when sending contact form data to my email. Not sure if what I have changed will accomplish what I want. Will need to test this on the live page due to the nature of the function.