### PR TITLE
Contact Pages - Updated .serialize() in scripts

### DIFF
--- a/scripts/contact_script.js
+++ b/scripts/contact_script.js
@@ -116,6 +116,7 @@ $(function(){
                 }, 5700);
                 setTimeout(function(){
                     $('.contactForm').css({'max-height':'35vh','background-color':'whitesmoke'});
+                    // max-height might be better as 43vh
                     $('footer').css({'margin-top':'15vh'});
                 }, 6000);
                 setTimeout(function(){
@@ -147,12 +148,19 @@ $(function(){
         $.when(validateAll).done(function(){
             e.preventDefault();
             var href = $('.contactForm').attr("action");
+                selectMessage = $('.contactForm input[name!=botCatfish], textarea');
             $.ajax({
                 type: "POST",
                 dataType: "json",
                 url: href,
                 // this needs to be tested before pushing to production - pending changes
-                data: $('.contactForm', 'input[name!=botCatfish]').serialize(),
+                // data: $('.contactForm', 'input[name!=botCatfish]').serialize(),
+                // data: $('.contactForm').not("#botCatfish").serialize(),
+                //data: $('.contactForm').not($("#botCatfish")).serialize(),
+
+                // After testing with console.log in dev tools, found the correct selector to use
+                // this will exclude hidden security field from being sent in messages
+                data: selectMessage.serialize(),
             });
         });
     });


### PR DESCRIPTION
Changed the selector used for what is sent from webpage contact form to my email. Main change is that the botCatfish field (which is meant to prevent bots from sending form) is no longer sent. This could be problematic in diagnosing future issues that may involve bots filling out form, but prefer this for now.