### PR TITLE
Contact Pages - Titles given nowrap

### DIFF
--- a/styles/contact_styles.css
+++ b/styles/contact_styles.css
@@ -55,6 +55,7 @@ h2, h3 {
     text-align: center;
     padding: 30px 20px 30px;
     margin: 0;
+    white-space: nowrap;
 }
 .contactForm {
     background: whitesmoke;
@@ -577,4 +578,8 @@ footer {
         -webkit-transform: scale(1.12);
         transition: all 0.3s ease;
     }
+}
+/* special viewport rules for very small mobile devices */
+@media only screen and (max-width:360px) {
+    
 }


### PR DESCRIPTION
In smaller mobile resolutions, the title of the contact form was wrapping into two lines which broke the design. Added `white-space: nowrap` to global style for contact page titles.