### PR TITLE
ASC and NM Portfolio - Mobile CSS splash adjstmt

### DIFF
--- a/nm-portfolio/styles/nm_styles.css
+++ b/nm-portfolio/styles/nm_styles.css
@@ -777,10 +777,14 @@ iframe {
         padding: 0;
         max-width: 100%;
         margin-top: 100px;
-        height: calc(100vh - 200px);
+        /* height: calc(100vh - 200px); */
         display: flex;
         flex-direction: column;
         justify-content: center;
+        height: calc(100svh - 200px);
+    }
+    .cred_arr {
+        padding-top: 0;
     }
     section {
         display: grid;
@@ -2146,8 +2150,9 @@ iframe {
     }
     .cred_arr {
         white-space: nowrap;
-        padding: 50px 10px 0;
+        /* padding: 50px 10px 0; */
         margin: 0;
+        padding: 0 10px 0;
     }
     .cred_arr::before {
         padding-right: 9px;

--- a/styles/asc_styles.css
+++ b/styles/asc_styles.css
@@ -411,11 +411,14 @@ p, li {
         position: relative;
         top: 0;
         min-width: 100vw;
-        height: 74vh;
+        /* height: 74vh; */
         background-size: 100% 100%;
         background-image: linear-gradient(30deg, rgb(50, 39, 73) 0%, rgb(65, 45, 103) 16%, rgb(86, 54, 148) 40%, rgb(62, 60, 127) 61%, rgb(47, 64, 114) 74%, rgb(43, 57, 96) 85%, rgb(38, 48, 73) 100%);
         z-index: 2;
         padding-bottom: 4vh;
+        height: 74svh;
+        align-items: center;
+        justify-content: center;
     }
     #splashGrad {
         width: 100vw;
@@ -440,7 +443,8 @@ p, li {
     #colorBand01 {
         display: block;
         position: relative;
-        height: 22vh;
+        /* height: 22vh; */
+        height: 22svh;
     }
     #colorBand02 {
         display: block;


### PR DESCRIPTION
Adjusted height declarations for splash/ hero areas for both pages. Previous declarations used "vh" units - these were changed to "svh" units in the hopes that design elements will adapt to any browser tool bars that take up vertical space. 

This will need to be tested once code is updated on server.