### PR TITLE
NM Portfolio - Redesign mobile modal close

### DIFF
--- a/nm-portfolio/cred.html
+++ b/nm-portfolio/cred.html
@@ -250,6 +250,19 @@
                                 <line fill="none" stroke="#9D90C5" stroke-width="8" x1="37.5" y1="12.5" x2="12.5" y2="37.5"></line>
                             </svg>
                         </button>
+
+                        <!-- New mobile close button here -->
+                        <span class=close_mobile>
+                            <svg class=details_arrow version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 16 31">
+                                <polygon points="15,1 15,30 0,16" stroke-linecap="round" stroke-linejoin="round" style="fill:#BDB0E6;;"/>
+                            </svg>
+                            <!-- <span class=pb_text>Return to portfolio...</span> -->
+                            <svg class=mobile_close_x version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 50 50">
+                                <line fill="none" stroke="#9D90C5" stroke-width="8" x1="12.5" y1="12.5" x2="37.5" y2="37.5"></line>
+                                <line fill="none" stroke="#9D90C5" stroke-width="8" x1="37.5" y1="12.5" x2="12.5" y2="37.5"></line>
+                            </svg>
+                        </span>
+
                         <aside class="g_modal">
                             <div class="modal_content_00">
                                 <!-- Title Area Victor's Mix -->
@@ -391,12 +404,12 @@
                             </div>
                         </aside>
                         <!-- Close button hidden in smaller resolutions -->
-                        <span class=close_mobile>
+                        <!-- <span class=close_mobile>
                             <svg class=details_arrow version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 31 31" xml:space="preserve">
                                 <polygon points="30,1 30,30 16,16" stroke-linecap="round" stroke-linejoin="round" style="fill:#BDB0E6;;"/>
                             </svg>
                             <span class=pb_text>Return to portfolio...</span>
-                        </span>
+                        </span> -->
                     </div>
                 </span>
                 <div class=portfolio_item_container>

--- a/nm-portfolio/scripts/nm_script.js
+++ b/nm-portfolio/scripts/nm_script.js
@@ -115,26 +115,37 @@ $(function(){
     // shows modal content based on which button is clicked on page
     for(let m=0;m<cBttn.length;m++){
         cBttn.on('click',function(){
+            // function modalCloseIn(){
+            //     $('.close_mobile').toggleClass('show_mobile_close');
+            // }
             var m = cBttn.index(this);
             $('body, html').css('overflow-y', 'hidden');
             $('.modal_screen').addClass('m_s_o_mobile');
             $('#headerMT').addClass('headerMT_modal');
+            $('.close_mobile').toggleClass('mobile_close_initial');
+            setTimeout(modalCloseIn,400);
             $('.head_flex').addClass('mobile_modal');
             $('#menuButton').addClass('mb_modal_open');
             $('.home_link').removeAttr('href');
             console.log('m:'+m);
-            $('.modal_content_0'+m).addClass('m_show');           
+            $('.modal_content_0'+m).addClass('m_show');
+            //setTimeout(modalCloseIn,300);        
         });
         // prevent page jump and double-fire
         return false
     }
 });
+function modalCloseIn(){
+    $('.close_mobile').toggleClass('show_mobile_close');
+}
 $(function(){
     // to close modal in MOBILE resolution only
     $('.close_mobile').on('click', function(event){
         event.preventDefault();
         $('.home_link').attr('href','#');
         $('body, html').css('overflow-y', 'scroll');
+        $('.close_mobile').toggleClass('mobile_close_initial');
+        setTimeout(modalCloseIn,300);
         $('.modal_screen').removeClass('m_s_o_mobile').one('transitionend', function(e){
             $('.modal_scroll').scrollTop(0,0);
             $('.modal_content_00, .modal_content_01').removeClass('m_show');

--- a/nm-portfolio/styles/nm_styles.css
+++ b/nm-portfolio/styles/nm_styles.css
@@ -1293,10 +1293,11 @@ iframe {
         /* new on 20221104 */
         top: 60px;
         /* fallback for mozilla browsers */
-        height: calc(100vh - 60px);
+        /* height: calc(100vh - 60px); */
         /* bottom of modal which included nav button
         back to portfolio was being hidden by browser UI */
-        height: 100svh;
+        /* height: 100svh; */
+        height: calc(100svh - 60px);
     }
     .m_s_o_mobile {
         transform: translate(0vw);
@@ -1305,23 +1306,56 @@ iframe {
     .m_container {
         position: relative;
         background-color: #662D91;
+        height: 100%;
+    }
+    .close_mobile {
+        position: absolute;
+        height: 60px;
+        display: flex;
+        display: none;
+        width: 100%;
+        /* background-color: #662D91; */
+        z-index: 201;
+        /* flex-wrap: wrap; */
+        justify-content: center;
+        align-items: center;
+        top: -60px;
+        transform: scaleX(1.5);
+        opacity: 0;
+        transition: transform 150ms ease, opacity 100ms ease-out;
+    }
+    .mobile_close_x {
+        height: 80%;
+        right: 4px;
+        position: absolute;
+    }
+    .mobile_close_initial {
+        display: flex;
+    }
+    .show_mobile_close {
+        /* display: flex; */
+        transform: scaleX(1);
+        opacity: 1;
+        transition: transform 300ms ease, opacity 550ms ease-in;
     }
     .g_modal {
         position: relative;
         margin: 0 auto 0;
         background-color: rgb(43, 57, 96);
-        height: auto;
+        /* height: auto; */
         transform: scale(1);
         opacity: 1;
         padding: 0;
-        height: calc(100vh - 160px);
+        /* height: calc(100vh - 160px); */
         /* new on 20221104 */
-        height: calc(100vh - 120px);
+        /* height: calc(100vh - 120px); */
+        height: 100%;
     }
     .modal_content_00, .modal_content_01 {
-        height: calc(100vh - 162px);
+        /* height: calc(100vh - 162px); */
         overflow: hidden;
-        height: calc(100vh - 122px);
+        /* height: calc(100vh - 122px); */
+        height: 100%;
     }
     .m_show {
         display: flex;
@@ -1330,6 +1364,9 @@ iframe {
     .modal_top {
         display: block;
         padding: 0;
+    }
+    .modal_scroll {
+        height: calc(100svh - 120px);
     }
     /* -- Only shown in larger resolutions -- */
     .modal_intro {
@@ -1393,17 +1430,6 @@ iframe {
     }
     .close_modal {
         display: none;
-    }
-    .close_mobile {
-        position: absolute;
-        height: 60px;
-        display: flex;
-        width: 100%;
-        background-color: #662D91;
-        z-index: 201;
-        flex-wrap: wrap;
-        justify-content: center;
-        align-items: center;
     }
     .gmj_logo {
         padding-bottom: 0;


### PR DESCRIPTION
After going live with portfolio page, noticed that there was an issue with displaying how my modals were intended to work. What I had not taken into account is the additional vertical space that would, potentially, be imposed by the browser displaying the page. Most notably, Brave browser had more vertical space taken up (vertically) than other browsers tested as there was an address bar on top as well as a tool bar at the bottom. Because the modal close button was placed at the very bottom when in mobile resolution, the button was entirely blocked by the Brave UI when scrolling down. This was even using svh as a unit as opposed to just vh (which was used originally) as the svh was only calculated on modal load which did not include the lower tool bar that pops up on scroll down. Due to the nature of this issue, the modal had to partly be redesigned. I did away with the close button appearing at the bottom, made it transparent, removed the text, and added an "x" svg for a visual cue. The close button div was also moved directly on top of the resized header with the modal open. As with most changes of this nature, this should be retested thoroughly once these changes are live on the server.