### PR TITLE
NM Portfolio - Full res bttn shows in mobile

### DIFF
--- a/nm-portfolio/styles/nm_styles.css
+++ b/nm-portfolio/styles/nm_styles.css
@@ -1141,7 +1141,6 @@ iframe {
         background-color: #11182d;
     }
     .port_button {
-        display: inherit;
         justify-content: center;
         align-items: center;
         flex: 1;


### PR DESCRIPTION
For the class "port_button", there was a conflicting declaration of `display:inherit;` which prevented the "more_info" class from applying `display:none`. This declaration was removed (mobile rules only) to fix the previous issue of both the full resolution button displaying alongside the mobile resolution modal button.