### PR TITLE
ASC - Splash for mobile fixed, more CSS changes

### DIFF
--- a/styles/asc_styles.css
+++ b/styles/asc_styles.css
@@ -22,11 +22,11 @@ h4 {
     font-family: 'Spartan', sans-serif;
     font-size: 18pt;
 }
-i {
+/* i {
     font-size: 5.15vw;
     font-family: 'Times New Roman', serif;
     line-height: 0.78;
-}
+} */
 p, li {
     font-family: 'Noto Sans KR', sans-serif;
     color: #91B4DF;
@@ -289,8 +289,8 @@ p, li {
         text-align: center;
     }
     i {
-        font-size: 20pt;
-        letter-spacing: 0.65pt;
+        padding: 0 0.22em;
+        font-size: 1.1em;
     }
     a {
         height: min-content;
@@ -412,19 +412,10 @@ p, li {
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        /* position: relative;
-        top: 0;
-        min-width: 100vw; */
-        /* height: 74vh; */
-        /* background-size: 100% 100%;
-        background-image: linear-gradient(30deg, rgb(50, 39, 73) 0%, rgb(65, 45, 103) 16%, rgb(86, 54, 148) 40%, rgb(62, 60, 127) 61%, rgb(47, 64, 114) 74%, rgb(43, 57, 96) 85%, rgb(38, 48, 73) 100%); */
         background: linear-gradient(30deg, rgb(50, 39, 73) 0%, rgb(65, 45, 103) 16%, rgb(86, 54, 148) 40%, rgb(62, 60, 127) 61%, rgb(47, 64, 114) 74%, rgb(43, 57, 96) 85%, rgb(38, 48, 73) 100%);
         z-index: 2;
-        /* padding-bottom: 4vh;
-        height: 74svh;
-        align-items: center;
-        justify-content: center; */
-        height: clamp(360px, 78svh, 78dvh);
+        /* height: clamp(360px, 78svh, 78dvh); */
+        height: clamp(360px, 74vh, 600px);
         margin: 0;
         padding: 0;
         transition: all 200ms ease;
@@ -434,37 +425,20 @@ p, li {
         height: 80vh;
     }
     #logoGlyph {
-        /* display: grid;
-        position: relative;
-        margin-top: 15vh;
-        justify-content: center; */
         filter: drop-shadow( 1px 10px 3px rgba(0, 0, 0, .7));
     }
     #logoText {
-        /* display: grid; */
         margin-top: 4vh;
-        /* justify-content: center; */
         filter: drop-shadow( 1px 10px 3px rgba(0, 0, 0, .7));
     }
     .fullValue, .logoValueContainer {
         display: none;
     }
-    #colorBand01 {
-        /* display: block;
-        position: relative; */
-        /* height: 22vh; */
-        height: 22svh;
-    }
-    #colorBand02 {
-        /* display: block;
-        width: 100vw; */
-        height: 19vh;
+    #colorBand01, #colorBand02 {
+        padding-bottom: 2em;
     }
     #colorBand03 {
-        /* display: block; */
         padding: 10px;
-        /* height: auto;
-        min-height: 9vh; */
     }
     .spacer {
         display: block;
@@ -1342,5 +1316,11 @@ p, li {
         max-width: 80vw;
         width: auto;
         margin-bottom: 0
+    }
+}
+/*=== Greater than HD resolution ===*/
+@media only screen and (min-width:2000px) {
+    .bg {
+        background-size: 7.23vw;
     }
 }


### PR DESCRIPTION
Splash for ASC in mobile resolution was fixed to make sure value statement appears on first load. 

Italicized value statement "always" modified.  Old font family removed and kept with the flow of main font used. 

ColorBand(s) modified from vh heights to use padding (em) for color design. Testing already carried out - code is already updated on server. 

This fixes issue #566 and issue #594.